### PR TITLE
Add reflect in z axis option

### DIFF
--- a/examples/plot_rz_slices_ring_source.py
+++ b/examples/plot_rz_slices_ring_source.py
@@ -75,5 +75,16 @@ for slice_index in range(1, len(mesh.phi_grid) - 1):
         outline=True,
         norm=LogNorm(),
         slice_index=slice_index,
+        reflect_in_z=True
+    )
+    plot.figure.savefig(f"rz_ring_source_reflected_{slice_index}.png")
+
+    plot = plot_mesh_tally_rz_slice(
+        tally=my_tally_result,
+        geometry=my_geometry,
+        outline=True,
+        norm=LogNorm(),
+        slice_index=slice_index,
     )
     plot.figure.savefig(f"rz_ring_source_{slice_index}.png")
+

--- a/examples/plot_rz_slices_ring_source.py
+++ b/examples/plot_rz_slices_ring_source.py
@@ -75,7 +75,7 @@ for slice_index in range(1, len(mesh.phi_grid) - 1):
         outline=True,
         norm=LogNorm(),
         slice_index=slice_index,
-        reflect_in_z=True
+        mirror=True
     )
     plot.figure.savefig(f"rz_ring_source_reflected_{slice_index}.png")
 

--- a/src/openmc_cylindrical_mesh_plotter/core.py
+++ b/src/openmc_cylindrical_mesh_plotter/core.py
@@ -143,7 +143,7 @@ def plot_mesh_tally_rz_slice(
     pixels: int = 40000,
     colorbar: bool = True,
     volume_normalization: bool = True,
-    reflect_in_z: bool = False,
+    mirror: bool = False,
     scaling_factor: typing.Optional[float] = None,
     colorbar_kwargs: dict = {},
     outline_kwargs: dict = _default_outline_kwargs,
@@ -184,7 +184,7 @@ def plot_mesh_tally_rz_slice(
         Whether or not to add a colorbar to the plot.
     volume_normalization : bool, optional
         Whether or not to normalize the data by the volume of the mesh elements.
-    reflect_in_z : bool, optional
+    mirror : bool, optional
         Whether to reflect the plot in the z axis to include negative r values.
     scaling_factor : float
         A optional multiplier to apply to the tally data prior to ploting.
@@ -255,7 +255,7 @@ def plot_mesh_tally_rz_slice(
             slice_index,
         )
     
-    if reflect_in_z:
+    if mirror:
         data_reflected = np.fliplr(data)
         data = np.concatenate((data_reflected, data), axis=1)
         x_min = x_max * -1
@@ -310,7 +310,7 @@ def plot_mesh_tally_rz_slice(
         rgb = (img * 256).astype(int)
         image_value = (rgb[..., 0] << 16) + (rgb[..., 1] << 8) + (rgb[..., 2])
         
-        if reflect_in_z:
+        if mirror:
             image_value_reflected = np.fliplr(image_value)
             image_value = np.concatenate((image_value_reflected, image_value), axis=1)
 

--- a/src/openmc_cylindrical_mesh_plotter/core.py
+++ b/src/openmc_cylindrical_mesh_plotter/core.py
@@ -143,6 +143,7 @@ def plot_mesh_tally_rz_slice(
     pixels: int = 40000,
     colorbar: bool = True,
     volume_normalization: bool = True,
+    reflect_in_z: bool = False,
     scaling_factor: typing.Optional[float] = None,
     colorbar_kwargs: dict = {},
     outline_kwargs: dict = _default_outline_kwargs,
@@ -183,6 +184,8 @@ def plot_mesh_tally_rz_slice(
         Whether or not to add a colorbar to the plot.
     volume_normalization : bool, optional
         Whether or not to normalize the data by the volume of the mesh elements.
+    reflect_in_z : bool, optional
+        Whether to reflect the plot in the z axis to include negative r values.
     scaling_factor : float
         A optional multiplier to apply to the tally data prior to ploting.
     colorbar_kwargs : dict
@@ -251,6 +254,11 @@ def plot_mesh_tally_rz_slice(
             score,
             slice_index,
         )
+    
+    if reflect_in_z:
+        data_reflected = np.fliplr(data)
+        data = np.concatenate((data_reflected, data), axis=1)
+        x_min = x_max * -1
 
     im = axes.imshow(data, extent=(x_min, x_max, y_min, y_max), **default_imshow_kwargs)
 
@@ -301,6 +309,10 @@ def plot_mesh_tally_rz_slice(
         # Combine R, G, B values into a single int
         rgb = (img * 256).astype(int)
         image_value = (rgb[..., 0] << 16) + (rgb[..., 1] << 8) + (rgb[..., 2])
+        
+        if reflect_in_z:
+            image_value_reflected = np.fliplr(image_value)
+            image_value = np.concatenate((image_value_reflected, image_value), axis=1)
 
         # Plot geometry image
         axes.contour(

--- a/tests/test_slice_of_data.py
+++ b/tests/test_slice_of_data.py
@@ -185,3 +185,14 @@ def test_phir_slice_of_data_circular_simulation_normalization(
 def test_rz_slice_of_data_point_simulation_combined(point_source_simulation):
     tally = point_source_simulation
     plot_mesh_tally_rz_slice(tally=[tally, tally])
+
+
+def test_rz_slice_of_data_point_simulation_flipping(point_source_simulation):
+    tally = point_source_simulation
+    plot = plot_mesh_tally_rz_slice(tally=tally)
+    width_plot = plot.get_xlim()[1] - plot.get_xlim()[0]
+
+    plot_flipped = plot_mesh_tally_rz_slice(tally=tally, mirror=True)
+    width_plot_flipped = plot_flipped.get_xlim()[1] - plot_flipped.get_xlim()[0]
+
+    assert width_plot * 2 == width_plot_flipped


### PR DESCRIPTION
I have added an option to plot rz slices reflected in the z axis, so that it is easier to visualise the entire cylindrical geometry.   You can turn this functionality on/off my making reflect_in_z True or False, but it defaults to False.  This fixes issue #11.

I have also added to one example to demonstrate this functionality.  It changes the rz ring source plot from:

![rz_ring_source_1_orig](https://github.com/fusion-energy/openmc_cylindrical_mesh_plotter/assets/18331093/1ace5b38-8803-4b3a-899a-01a420059251)

to:

![rz_ring_source_reflected_1](https://github.com/fusion-energy/openmc_cylindrical_mesh_plotter/assets/18331093/5ff2d26f-2744-4d24-81da-2dcb6806e230)

The only problem is that the colorbar is not resized in the reflected plot, so it is larger than the image.  Does anyone know how to fix this?

There may be a better way to implement this, so feedback is appreciated!

I have run the tests and they passed but there were several warnings - were these present before?  I have also checked that all the examples still run.



